### PR TITLE
Feature: Improve CLI UX + Gitignore Support + Output Summary

### DIFF
--- a/.changeset/hot-pans-happen.md
+++ b/.changeset/hot-pans-happen.md
@@ -1,0 +1,5 @@
+---
+'gleanup': minor
+---
+
+Support .gitignore

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "cleye": "^1.3.4",
     "clipboardy": "^4.0.0",
     "globby": "^14.1.0",
-    "istextorbinary": "^9.5.0"
+    "istextorbinary": "^9.5.0",
+    "pretty-bytes": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "release": "npm run build && changeset publish",
     "lint": "tsc --noEmit",
     "test": "ava",
+    "local:run": " pnpm build && npx gleanup .",
     "upgrade-deps": "npx taze -r --interactive",
     "check-deps": "npx taze -r"
   },
@@ -67,6 +68,6 @@
     "ansis": "^4.0.0",
     "cleye": "^1.3.4",
     "clipboardy": "^4.0.0",
-    "glob": "^11.0.2"
+    "globby": "^14.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "ansis": "^4.0.0",
     "cleye": "^1.3.4",
     "clipboardy": "^4.0.0",
-    "globby": "^14.1.0"
+    "globby": "^14.1.0",
+    "istextorbinary": "^9.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,9 @@ importers:
       clipboardy:
         specifier: ^4.0.0
         version: 4.0.0
-      glob:
-        specifier: ^11.0.2
-        version: 11.0.2
+      globby:
+        specifier: ^14.1.0
+        version: 14.1.0
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.4
@@ -975,11 +975,6 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
-  glob@11.0.2:
-    resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
-    engines: {node: 20 || >=22}
-    hasBin: true
-
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
@@ -1249,10 +1244,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jackspeak@4.1.0:
-    resolution: {integrity: sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==}
-    engines: {node: 20 || >=22}
-
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -1310,10 +1301,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.1.0:
-    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
-    engines: {node: 20 || >=22}
-
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -1359,10 +1346,6 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
-
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -1537,10 +1520,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
 
   path-type@3.0.0:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
@@ -3117,15 +3096,6 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.0.2:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.1.0
-      minimatch: 10.0.1
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
-
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
@@ -3376,10 +3346,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jackspeak@4.1.0:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-
   joycon@3.1.1: {}
 
   js-string-escape@1.0.1: {}
@@ -3426,8 +3392,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.1.0: {}
-
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -3464,10 +3428,6 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
-
-  minimatch@10.0.1:
-    dependencies:
-      brace-expansion: 2.0.1
 
   minimatch@3.1.2:
     dependencies:
@@ -3626,11 +3586,6 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
-
-  path-scurry@2.0.0:
-    dependencies:
-      lru-cache: 11.1.0
       minipass: 7.1.2
 
   path-type@3.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       istextorbinary:
         specifier: ^9.5.0
         version: 9.5.0
+      pretty-bytes:
+        specifier: ^7.0.0
+        version: 7.0.0
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.4
@@ -1617,6 +1620,10 @@ packages:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-bytes@7.0.0:
+    resolution: {integrity: sha512-U5otLYPR3L0SVjHGrkEUx5mf7MxV2ceXeE7VwWPk+hyzC5drNohsOGNPDZqxCqyX1lkbEN4kl1LiI8QFd7r0ZA==}
+    engines: {node: '>=20'}
 
   pretty-ms@9.2.0:
     resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
@@ -3668,6 +3675,8 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.5.3: {}
+
+  pretty-bytes@7.0.0: {}
 
   pretty-ms@9.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       globby:
         specifier: ^14.1.0
         version: 14.1.0
+      istextorbinary:
+        specifier: ^9.5.0
+        version: 9.5.0
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.4
@@ -562,6 +565,10 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  binaryextensions@6.11.0:
+    resolution: {integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==}
+    engines: {node: '>=4'}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -774,6 +781,10 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editions@6.21.0:
+    resolution: {integrity: sha512-ofkXJtn7z0urokN62DI3SBo/5xAtF0rR7tn+S/bSYV79Ka8pTajIIl+fFQ1q88DQEImymmo97M4azY3WX/nUdg==}
+    engines: {node: '>=4'}
 
   emittery@1.1.0:
     resolution: {integrity: sha512-rsX7ktqARv/6UQDgMaLfIqUWAEzzbCQiVh7V9rhDXp6c37yoJcks12NVD+XPkgl4AEavmNhVfrhGoqYwIsMYYA==}
@@ -1240,6 +1251,10 @@ packages:
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
+
+  istextorbinary@9.5.0:
+    resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
+    engines: {node: '>=4'}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -1879,6 +1894,10 @@ packages:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
 
+  textextensions@6.11.0:
+    resolution: {integrity: sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==}
+    engines: {node: '>=4'}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -1989,6 +2008,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  version-range@4.14.0:
+    resolution: {integrity: sha512-gjb0ARm9qlcBAonU4zPwkl9ecKkas+tC2CGwFfptTCWWIVTWY1YUbT2zZKsOAF1jR/tNxxyLwwG0cb42XlYcTg==}
+    engines: {node: '>=4'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -2587,6 +2610,10 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  binaryextensions@6.11.0:
+    dependencies:
+      editions: 6.21.0
+
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -2808,6 +2835,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  editions@6.21.0:
+    dependencies:
+      version-range: 4.14.0
 
   emittery@1.1.0: {}
 
@@ -3339,6 +3370,12 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  istextorbinary@9.5.0:
+    dependencies:
+      binaryextensions: 6.11.0
+      editions: 6.21.0
+      textextensions: 6.11.0
 
   jackspeak@3.4.3:
     dependencies:
@@ -3972,6 +4009,10 @@ snapshots:
       glob: 10.4.5
       minimatch: 9.0.5
 
+  textextensions@6.11.0:
+    dependencies:
+      editions: 6.21.0
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -4098,6 +4139,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  version-range@4.14.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,11 @@ const argv = cli({
   },
 });
 
+function logger(...args: any[]) {
+  if (argv.flags.print) return;
+  console.log(...args);
+}
+
 const DEFUALT_IGNORE = ['.git/**', 'pnpm-lock.yaml', 'yarn.lock', 'package-lock.json', 'bun.lock'];
 
 const cwd = path.resolve(argv._.directory || process.cwd());
@@ -75,24 +80,24 @@ function checkGitIgnore() {
   const hasGitignore = existsSync(gitignorePath);
 
   if (hasGitignore) {
-    console.log(`   ${MARK_BULLET} ${c.bold('.gitignore')} found – applying its rules`);
+    logger(`   ${MARK_BULLET} ${c.bold('.gitignore')} found – applying its rules`);
   } else {
-    console.log(`   ${MARK_BULLET} ${c.bold('.gitignore')} not found – no rules applied`);
+    logger(`   ${MARK_BULLET} ${c.bold('.gitignore')} not found – no rules applied`);
   }
 }
 
 function logInfomation() {
-  console.log(c.bold(c.blue(`\n${MARK_INFO} ${c.bgBlue('Gleanup')} v${version} - Dump files as Markdown to clipboard\n`)));
+  logger(c.bold(c.blue(`\n${MARK_INFO} ${c.bgBlue('Gleanup')} v${version} - Dump files as Markdown to clipboard\n`)));
 
-  console.log(`\n${MARK_INFO} Target directory::\n   ${cwd}\n`);
-  console.log(`${MARK_INFO} Scan settings:`);
+  logger(`\n${MARK_INFO} Target directory::\n   ${cwd}\n`);
+  logger(`${MARK_INFO} Scan settings:`);
   if (extFilter) {
-    console.log(`   ${MARK_BULLET} Extension: .${extFilter}`);
+    logger(`   ${MARK_BULLET} Extension: .${extFilter}`);
   } else {
-    console.log(`   ${MARK_BULLET} Extension: (no filter)`);
+    logger(`   ${MARK_BULLET} Extension: (no filter)`);
   }
-  console.log(`   ${MARK_BULLET} Pattern: "${argv.flags.pattern}"`);
-  console.log(`   ${MARK_BULLET} Ignored: ${ignorePatterns.length === 0 ? '(none)' : ignorePatterns.map(p => `"${p}"`).join(', ')}`);
+  logger(`   ${MARK_BULLET} Pattern: "${argv.flags.pattern}"`);
+  logger(`   ${MARK_BULLET} Ignored: ${ignorePatterns.length === 0 ? '(none)' : ignorePatterns.map(p => `"${p}"`).join(', ')}`);
   checkGitIgnore();
 }
 
@@ -110,15 +115,15 @@ async function main() {
     })
     .join('\n');
 
-  console.log(c.bold(`\n${MARK_INFO} Files collected:`));
+  logger(c.bold(`\n${MARK_INFO} Files collected:`));
   for (const file of files) {
-    console.log(`   ${MARK_BULLET} ${file.path}`);
+    logger(`   ${MARK_BULLET} ${file.path}`);
   }
 
   if (argv.flags.output) {
     const outputPath = path.resolve(argv.flags.output);
     await writeFile(outputPath, output, 'utf-8');
-    console.log(`📝 Written output to ${outputPath}`);
+    logger(`📝 Written output to ${outputPath}`);
   }
 
   await clipboard.write(output);
@@ -131,7 +136,7 @@ async function main() {
     throw new Error('No files found matching the criteria.');
   }
 
-  console.log(c.green(`\n${MARK_CHECK} Copied ${files.length} file(s) to clipboard from:\n  ${cwd}\n`));
+  logger(c.green(`\n${MARK_CHECK} Copied ${files.length} file(s) to clipboard from:\n  ${cwd}\n`));
 }
 main().catch(err => {
   console.error('\n❌ Error:\n', err);

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import c from 'ansis';
 import { MARK_BULLET, MARK_CHECK, MARK_INFO } from './constant';
 import { version } from './version';
 import { existsSync } from 'fs';
+import { isText } from 'istextorbinary';
 
 const argv = cli({
   name: 'gleanup',
@@ -63,6 +64,11 @@ async function listFilesWithContent() {
       const fullPath = path.join(cwd, file);
       const fileStat = await stat(fullPath);
       if (!fileStat.isFile()) return null;
+
+      // ⛔ Skip non-text files
+      const isTextFile = isText(fullPath);
+      if (!isTextFile) return null;
+
       if (extFilter && !file.endsWith(extFilter)) return null;
 
       return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,21 +75,24 @@ function checkGitIgnore() {
   const hasGitignore = existsSync(gitignorePath);
 
   if (hasGitignore) {
-    console.log(`${MARK_BULLET} ${c.bold('.gitignore')} found – applying its rules`);
+    console.log(`   ${MARK_BULLET} ${c.bold('.gitignore')} found – applying its rules`);
+  } else {
+    console.log(`   ${MARK_BULLET} ${c.bold('.gitignore')} not found – no rules applied`);
   }
 }
 
 function logInfomation() {
-  console.log(c.bold(c.blue(`\n${MARK_INFO} Gleanup - File dumper v${version}`)));
+  console.log(c.bold(c.blue(`\n${MARK_INFO} ${c.bgBlue('Gleanup')} v${version} - Dump files as Markdown to clipboard\n`)));
 
-  console.log(`\n${MARK_INFO} Searching for files in:\n   ${cwd}\n`);
+  console.log(`\n${MARK_INFO} Target directory::\n   ${cwd}\n`);
+  console.log(`${MARK_INFO} Scan settings:`);
   if (extFilter) {
-    console.log(`${MARK_BULLET} Extension: "${extFilter}"`);
+    console.log(`   ${MARK_BULLET} Extension: .${extFilter}`);
   } else {
-    console.log(`${MARK_BULLET} Extension: "all"`);
+    console.log(`   ${MARK_BULLET} Extension: (no filter)`);
   }
-  console.log(`${MARK_BULLET} Pattern: "${argv.flags.pattern}"`);
-  console.log(`${MARK_BULLET} Ignoring: "${ignorePatterns.join(', ')}"`);
+  console.log(`   ${MARK_BULLET} Pattern: "${argv.flags.pattern}"`);
+  console.log(`   ${MARK_BULLET} Ignored: ${ignorePatterns.length === 0 ? '(none)' : ignorePatterns.map(p => `"${p}"`).join(', ')}`);
   checkGitIgnore();
 }
 
@@ -128,7 +131,7 @@ async function main() {
     throw new Error('No files found matching the criteria.');
   }
 
-  console.log(c.green(`\n${MARK_CHECK} Copied ${files.length} file(s) from ${cwd} to clipboard`));
+  console.log(c.green(`\n${MARK_CHECK} Copied ${files.length} file(s) to clipboard from:\n  ${cwd}\n`));
 }
 main().catch(err => {
   console.error('\n❌ Error:\n', err);


### PR DESCRIPTION
### 🔧 What’s changed

* ✅ Switched from `glob` to [globby](https://github.com/sindresorhus/globby)
  - → now supports `.gitignore` automatically (via `gitignore: true`)
* ✅ Skip binary files (e.g. images, PDFs) using `istextorbinary`
* ✅ Added `pretty-bytes` to summarize output size
* ✅ Added custom `logger()` function
   - → automatically **suppresses logs when `--print` is used**
* ✅ Improved CLI logs and summary format
  * Show summary only if meaningful
  * Better grouping for scan config
* ✅ Small polish to output formatting + UX

### 🧪 Example CLI output

```bash
Gleanup v1.1.0 - Dump files as Markdown to clipboard

ℹ Target directory::
   /Users/thadawangthammang/gits/thaitype/gleanup

ℹ Scan settings:
   • Extension: (no filter)
   • Pattern: "**"
   • Ignored: (none)
   • .gitignore found – applying its rules

ℹ Files collected:
   • CHANGELOG.md
   • README.md
   • bin.mjs
   • package.json
   • tsconfig.json
   • src/constant.ts
   • src/main.ts
   • src/version.ts

ℹ Summary Output size: 22.5 kB

✔ Copied 8 file(s) to clipboard from:
  /Users/thadawangthammang/gits/thaitype/gleanup

✔ Done!
```

### ✅ Why this is useful

* Makes the CLI safer + smarter when scanning projects
* Prevents unexpected files from being included (binary / lockfiles)
* More consistent DX for LLM/chat context copy
* Easier to pipe when running in `--print` mode
